### PR TITLE
chore: exit non-zero on >= 400 HTTP status code

### DIFF
--- a/.github/workflows/test-ig-token.yaml
+++ b/.github/workflows/test-ig-token.yaml
@@ -16,4 +16,5 @@ jobs:
           curl \
             --verbose \
             --location \
+            --fail-with-body \
             "https://graph.instagram.com/v21.0/28395689843380207/media?fields=media_url,caption,permalink&access_token=$IG_ACCESS_TOKEN"


### PR DESCRIPTION
This causes the 'test-ig-token' GHA workflow to fail if/when the curl against the
IG API errors.
