### PR TITLE
fix: IG token refresher no longer 400s

### DIFF
--- a/.github/workflows/refresh-ig-token.yaml
+++ b/.github/workflows/refresh-ig-token.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   refresh-token:
     runs-on: ubuntu-latest
-    name: refresh-token
+    name: refresh-ig-token
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -19,7 +19,8 @@ jobs:
           node-version-file: .nvmrc
       - name: npm-install
         run: npm install
-      - name: fetch-ig-media
+      - name: refresh-ig-token
+        id: refresh-ig-token
         env:
           IG_ACCESS_TOKEN: ${{ secrets.IG_ACCESS_TOKEN }}
         run: npm run refresh-ig-token
@@ -27,5 +28,14 @@ jobs:
         uses: hmanzur/actions-set-secret@v2.0.0
         with:
           name: IG_ACCESS_TOKEN
-          value: ${{ steps.instagram.outputs.access_token }}
+          value: ${{ steps.refresh-ig-token.outputs.ig-access-token }}
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - name: test-updated-gh-secret
+        env:
+          IG_ACCESS_TOKEN: ${{ secrets.IG_ACCESS_TOKEN }}
+        run: |
+          curl \
+            --verbose \
+            --location \
+            --fail-with-body \
+            "https://graph.instagram.com/v21.0/28395689843380207/media?fields=media_url,caption,permalink&access_token=$IG_ACCESS_TOKEN"

--- a/refresh-ig-token.js
+++ b/refresh-ig-token.js
@@ -2,19 +2,25 @@ const axios = require('axios');
 const core = require('@actions/core');
 
 refreshIgToken = async () => {
-  const result = await axios.get('https://graph.instagram.com/refresh_access_token', {
-    grant_type: 'ig_refresh_token',
-    access_token: process.env.IG_ACCESS_TOKEN,
+  const result = await axios({
+    url: 'https://graph.instagram.com/refresh_access_token',
+    params: {
+      grant_type: 'ig_refresh_token',
+      access_token: process.env.IG_ACCESS_TOKEN
+    }
   });
 
   const token = result.data.access_token;
-  core.setSecret(token)
+  core.setSecret(token);
 
   // test use of the new token & throw error before updating the GHA secret if
   // its use fails.
-  await axios.get('https://graph.instagram.com/v21.0/28395689843380207/media', {
-    access_token: token,
-    fields: 'media_url,caption,permalink'
+  await axios({
+    url: 'https://graph.instagram.com/v21.0/28395689843380207/media',
+    params: {
+      access_token: token,
+      fields: 'media_url,caption,permalink'
+    }
   });
 
   core.setOutput('ig-access-token', token);


### PR DESCRIPTION
This also ensures the GHA IG_ACCESS_TOKEN secret is properly set.
