### PR TITLE
chore: remove unused NPM registry configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: npm-install
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.PERSONAL_ACCESS_TOKEN }}" >> .npmrc
-          npm install
+        run: npm install
       - name: test
         run: npm test
       - name: fetch-feed

--- a/.github/workflows/generate-feeds.yaml
+++ b/.github/workflows/generate-feeds.yaml
@@ -19,9 +19,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: npm-install
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.PERSONAL_ACCESS_TOKEN }}" >> .npmrc
-          npm install
+        run: npm install
       - name: test
         run: npm test
       - name: fetch-ig-media


### PR DESCRIPTION
This is no longer necessary now that feeder does its own IG token
refreshing.
