### PR TITLE
fix: correctly import axios func

### DIFF
--- a/refresh-ig-token.js
+++ b/refresh-ig-token.js
@@ -1,4 +1,4 @@
-import * as axios from 'axios';
+import axios from 'axios';
 import * as core from '@actions/core';
 
 const refreshIgToken = async () => {


### PR DESCRIPTION
This fixes:

```
TypeError: axios is not a function
```

...as seen at https://github.com/mdb/feeder/actions/runs/18077456649/job/51436014809

Signed-off-by: Mike Ball <mikedball@gmail.com>
